### PR TITLE
Skip verifying the peer name

### DIFF
--- a/app/Nominet/Epp.php
+++ b/app/Nominet/Epp.php
@@ -10,7 +10,7 @@ class Epp
     {
         $timeout = @ini_get('default_socket_timeout');
         $flags = null;
-        $options = null;
+        $options = ['ssl' => ['verify_peer_name' => false]];
         $context = stream_context_create($options);
         $flags = STREAM_CLIENT_CONNECT;
 


### PR DESCRIPTION
On the production EPP, the common name on the SSL certificate is epp.nominet.org.uk, you might find that PHP has trouble connecting as it is expecting it to be ror-epp.nominet.org.uk. There would probably be a security risk in doing so for a long running project, but for next week, I think you're safe.

I've not tested the implementation, just saw a few people on Acorn mention connection problems and thought it might be this.